### PR TITLE
add more info to the staker info

### DIFF
--- a/src/hooks/useStakerInfo.js
+++ b/src/hooks/useStakerInfo.js
@@ -11,15 +11,34 @@ export default function useStakerInfo(address) {
                 return
             }
             const stakerInfoResponse = await stakingContract.contract.methods.getStakerInfo(address).call()
-            const rewardResponse = await stakingContract.contract.methods.calculateReward(address).call()
-            setStakerInfo({
-                hasStaked: true,
-                amount: new BigNumber(stakerInfoResponse[0]),
-                stakingTime: parseInt(stakerInfoResponse[1], 10),
-                option: parseInt(stakerInfoResponse[2], 10),
-                rewardTaken: stakerInfoResponse[3],
-                reward: new BigNumber(rewardResponse)
-            })
+
+            if (!new BigNumber(stakerInfoResponse[0]).isZero()) {
+                const [rewardResponse, ...stakedFor] = await Promise.all([
+                    stakingContract.contract.methods.calculateReward(address).call(),
+                    stakingContract.contract.methods.stakedFor1().call(),
+                    stakingContract.contract.methods.stakedFor2().call(),
+                    stakingContract.contract.methods.stakedFor3().call(),
+                ])
+
+                const option = parseInt(stakerInfoResponse[2], 10)
+                const stakingTime = parseInt(stakerInfoResponse[1], 10)
+                const stakedForNumbers = stakedFor.map(value => parseInt(value, 10))
+
+                const startOfStakeMillis = stakingTime * 1000
+                const endOfStakeMillis = (stakedForNumbers[option] + stakingTime) * 1000
+                setStakerInfo({
+                    hasStaked: true,
+                    amount: new BigNumber(stakerInfoResponse[0]),
+                    stakingTime,
+                    startOfStakeMillis,
+                    endOfStakeMillis,
+                    startOfStake: new Date(startOfStakeMillis),
+                    endOfStake: new Date(endOfStakeMillis),
+                    option,
+                    rewardTaken: stakerInfoResponse[3],
+                    reward: new BigNumber(rewardResponse)
+                })
+            }
         }
         fetchStakerInfo()
     }, [setStakerInfo, address])


### PR DESCRIPTION
I've improved the logic of the `useStakerInfo` hook, it now contains more information about the current staking period.

<img width="686" alt="Screenshot 2021-02-17 at 10 15 30" src="https://user-images.githubusercontent.com/839848/108182427-4a4aea00-7109-11eb-9ea9-6863da6a7d90.png">
